### PR TITLE
Some improvements for the RibbonProject

### DIFF
--- a/WpfProjectTypes/RibbonProject.sln
+++ b/WpfProjectTypes/RibbonProject.sln
@@ -3,9 +3,9 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 16
 VisualStudioVersion = 16.0.29123.89
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "CoreProject", "CoreProject\CoreProject.csproj", "{58A5588C-6D96-40A0-840A-91689C1EE9BA}"
-EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "RibbonProject", "RibbonProject\RibbonProject.csproj", "{3C06883B-B212-4B20-997B-50BBE906CF90}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "CoreProject", "CoreProject\CoreProject.csproj", "{58A5588C-6D96-40A0-840A-91689C1EE9BA}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -13,14 +13,14 @@ Global
 		Release|Any CPU = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		{58A5588C-6D96-40A0-840A-91689C1EE9BA}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{58A5588C-6D96-40A0-840A-91689C1EE9BA}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{58A5588C-6D96-40A0-840A-91689C1EE9BA}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{58A5588C-6D96-40A0-840A-91689C1EE9BA}.Release|Any CPU.Build.0 = Release|Any CPU
 		{3C06883B-B212-4B20-997B-50BBE906CF90}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{3C06883B-B212-4B20-997B-50BBE906CF90}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{3C06883B-B212-4B20-997B-50BBE906CF90}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{3C06883B-B212-4B20-997B-50BBE906CF90}.Release|Any CPU.Build.0 = Release|Any CPU
+		{58A5588C-6D96-40A0-840A-91689C1EE9BA}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{58A5588C-6D96-40A0-840A-91689C1EE9BA}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{58A5588C-6D96-40A0-840A-91689C1EE9BA}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{58A5588C-6D96-40A0-840A-91689C1EE9BA}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/WpfProjectTypes/RibbonProject/Behaviors/RibbonTabsBehavior.cs
+++ b/WpfProjectTypes/RibbonProject/Behaviors/RibbonTabsBehavior.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.ObjectModel;
+using System.Collections.ObjectModel;
 using System.Linq;
 using System.Windows;
 using System.Windows.Controls;
@@ -47,7 +47,8 @@ namespace RibbonProject.Behaviors
         private void OnNavigated(object sender, string e)
         {
             var frame = sender as Frame;
-            if (frame.Content is Page page)
+            if (frame != null
+                && frame.Content is Page page)
             {
                 UpdateTabs(page);
             }

--- a/WpfProjectTypes/RibbonProject/Behaviors/RibbonTabsBehavior.cs
+++ b/WpfProjectTypes/RibbonProject/Behaviors/RibbonTabsBehavior.cs
@@ -1,4 +1,4 @@
-using System.Collections.ObjectModel;
+﻿using System.Collections.ObjectModel;
 using System.Linq;
 using System.Windows;
 using System.Windows.Controls;
@@ -12,6 +12,15 @@ namespace RibbonProject.Behaviors
 {
     public class RibbonTabsBehavior : Behavior<Ribbon>
     {
+        public static readonly DependencyProperty IsHomeTabProperty = DependencyProperty.RegisterAttached(
+            "IsHomeTab", typeof(bool), typeof(RibbonTabsBehavior), new PropertyMetadata(default(bool)));
+
+        public static void SetIsHomeTab(DependencyObject element, bool value)
+            => element.SetValue(IsHomeTabProperty, value);
+
+        public static bool GetIsHomeTab(DependencyObject element)
+            => (bool)element.GetValue(IsHomeTabProperty);
+
         public static bool GetIsTabFromPage(RibbonTabItem item)
             => (bool)item.GetValue(IsTabFromPageProperty);
 
@@ -66,23 +75,25 @@ namespace RibbonProject.Behaviors
 
         private void SetupHomeGroups(Collection<RibbonGroupBox> homeGroups)
         {
-            var homeTab = AssociatedObject.Tabs.FirstOrDefault();
-            if (homeTab != null)
+            var homeTab = AssociatedObject.Tabs.FirstOrDefault(GetIsHomeTab);
+            if (homeTab == null)
             {
-                for (int i = homeTab.Groups.Count - 1; i >= 0; i--)
+                return;
+            }
+
+            for (int i = homeTab.Groups.Count - 1; i >= 0; i--)
+            {
+                if (GetIsGroupFromPage(homeTab.Groups[i]))
                 {
-                    if (GetIsGroupFromPage(homeTab.Groups[i]))
-                    {
-                        homeTab.Groups.RemoveAt(i);
-                    }
+                    homeTab.Groups.RemoveAt(i);
                 }
             }
 
-            foreach (var group in homeGroups)
+            foreach (var @group in homeGroups)
             {
-                if (GetIsGroupFromPage(group))
+                if (GetIsGroupFromPage(@group))
                 {
-                    homeTab.Groups.Add(group);
+                    homeTab.Groups.Add(@group);
                 }
             }
         }

--- a/WpfProjectTypes/RibbonProject/RibbonProject.csproj
+++ b/WpfProjectTypes/RibbonProject/RibbonProject.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
+<Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
 
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
@@ -13,7 +13,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Fluent.Ribbon" Version="7.0.0" />
+    <PackageReference Include="Fluent.Ribbon" Version="7.0.1" />
     <PackageReference Include="MahApps.Metro" Version="2.0.0-alpha0490" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="3.0.0" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">

--- a/WpfProjectTypes/RibbonProject/Views/MainPage.xaml
+++ b/WpfProjectTypes/RibbonProject/Views/MainPage.xaml
@@ -1,4 +1,4 @@
-﻿<Page
+<Page
     x:Class="RibbonProject.Views.MainPage"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
@@ -16,10 +16,17 @@
         <models:RibbonPageConfiguration>
             <models:RibbonPageConfiguration.HomeGroups>
                 <Fluent:RibbonGroupBox
+                    State="Large"
+                    MinWidth="150"
+                    behaviors:RibbonTabsBehavior.IsGroupFromPage="True"
+                    Header="{x:Static strings:Resources.ShellPageRibbonHomeGroupCommon1Header}">
+                </Fluent:RibbonGroupBox>
+                <Fluent:RibbonGroupBox
                     State="Middle"
                     MinWidth="150"
                     behaviors:RibbonTabsBehavior.IsGroupFromPage="True"
-                    Header="{x:Static strings:Resources.MainPageRibbonHomeGroup1Header}" />
+                    Header="{x:Static strings:Resources.ShellPageRibbonHomeGroupCommon2Header}">
+                </Fluent:RibbonGroupBox>
             </models:RibbonPageConfiguration.HomeGroups>
             <models:RibbonPageConfiguration.Tabs>
                 <Fluent:RibbonTabItem

--- a/WpfProjectTypes/RibbonProject/Views/ShellWindow.xaml
+++ b/WpfProjectTypes/RibbonProject/Views/ShellWindow.xaml
@@ -1,4 +1,4 @@
-﻿<controls:MetroWindow
+<controls:MetroWindow
     x:Class="RibbonProject.Views.ShellWindow"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
@@ -33,7 +33,7 @@
                 <!--Backstage-->
                 <Fluent:Ribbon.Menu>
                     <Fluent:Backstage UseHighestAvailableAdornerLayer="False">
-                        <Fluent:BackstageTabControl x:Name="backstageTabControl">
+                        <Fluent:BackstageTabControl x:Name="backstageTabControl" SelectedContentMargin="0">
                             <i:Interaction.Behaviors>
                                 <behaviors:BackstageTabNavigationBehavior x:Name="navigationBehavior" />
                             </i:Interaction.Behaviors>

--- a/WpfProjectTypes/RibbonProject/Views/ShellWindow.xaml
+++ b/WpfProjectTypes/RibbonProject/Views/ShellWindow.xaml
@@ -1,4 +1,4 @@
-<controls:MetroWindow
+﻿<controls:MetroWindow
     x:Class="RibbonProject.Views.ShellWindow"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
@@ -51,7 +51,8 @@
                 <!--Tabs-->
                 <Fluent:RibbonTabItem
                     Fluent:KeyTip="A"
-                    Header="{x:Static strings:Resources.ShellPageRibbonTabHomeHeader}">
+                    Header="{x:Static strings:Resources.ShellPageRibbonTabHomeHeader}"
+                    behaviors:RibbonTabsBehavior.IsHomeTab="True">
                     <Fluent:RibbonGroupBox
                         State="Middle"
                         MinWidth="150"

--- a/WpfProjectTypes/RibbonProject/Views/ShellWindow.xaml
+++ b/WpfProjectTypes/RibbonProject/Views/ShellWindow.xaml
@@ -53,15 +53,9 @@
                     Fluent:KeyTip="A"
                     Header="{x:Static strings:Resources.ShellPageRibbonTabHomeHeader}">
                     <Fluent:RibbonGroupBox
-                        State="Large"
-                        MinWidth="150"
-                        Header="{x:Static strings:Resources.ShellPageRibbonHomeGroupCommon1Header}">
-                    </Fluent:RibbonGroupBox>
-                    <Fluent:RibbonGroupBox
                         State="Middle"
                         MinWidth="150"
-                        Header="{x:Static strings:Resources.ShellPageRibbonHomeGroupCommon2Header}">
-                    </Fluent:RibbonGroupBox>
+                        Header="{x:Static strings:Resources.MainPageRibbonHomeGroup1Header}" />
                 </Fluent:RibbonTabItem>
             </Fluent:Ribbon>
             <controls:SplitView

--- a/WpfProjectTypes/RibbonProject/Views/ShellWindow.xaml.cs
+++ b/WpfProjectTypes/RibbonProject/Views/ShellWindow.xaml.cs
@@ -10,16 +10,31 @@ using RibbonProject.ViewModels;
 
 namespace RibbonProject.Views
 {
-    public partial class ShellWindow : MetroWindow, IShellWindow
+    public partial class ShellWindow : MetroWindow, IShellWindow, IRibbonWindow
     {
-        private RibbonTitleBar _titleBar;
-
         public ShellWindow(ShellWindowViewModel viewModel, IPageService pageService)
         {
             InitializeComponent();
             DataContext = viewModel;
             navigationBehavior.Initialize(pageService);
         }
+
+        /// <summary>
+        /// Gets ribbon titlebar.
+        /// </summary>
+        public RibbonTitleBar TitleBar
+        {
+            get => (RibbonTitleBar)GetValue(TitleBarProperty);
+            private set => SetValue(TitleBarPropertyKey, value);
+        }
+
+        // ReSharper disable once InconsistentNaming
+        private static readonly DependencyPropertyKey TitleBarPropertyKey = DependencyProperty.RegisterReadOnly(nameof(TitleBar), typeof(RibbonTitleBar), typeof(ShellWindow), new PropertyMetadata());
+
+        /// <summary>
+        /// <see cref="DependencyProperty"/> for <see cref="TitleBar"/>.
+        /// </summary>
+        public static readonly DependencyProperty TitleBarProperty = TitleBarPropertyKey.DependencyProperty;
 
         public Frame GetNavigationFrame()
             => shellFrame;
@@ -38,9 +53,9 @@ namespace RibbonProject.Views
 
         private void MetroWindow_Loaded(object sender, RoutedEventArgs e)
         {
-            _titleBar = this.FindChild<RibbonTitleBar>("RibbonTitleBar");
-            _titleBar.InvalidateArrange();
-            _titleBar.UpdateLayout();
+            TitleBar = this.FindChild<RibbonTitleBar>("RibbonTitleBar");
+            TitleBar.InvalidateArrange();
+            TitleBar.UpdateLayout();
         }
     }
 }


### PR DESCRIPTION
Hi,

i was asked by @LucasHaines to do a review of the RibbonProject.
Nice to see Fluent.Ribbon being added to template studio! :-) Makes me proud of my work.

There were some minor things that i improved.

- I updated Fluent.Ribbon from 7.0.0 to 7.0.1 as i just released that version and it contains some "important" fixes => https://github.com/fluentribbon/Fluent.Ribbon/releases/tag/v7.0.1
- For the best interop experience between MahApps.Metro and Fluent.Ribbon the window hosting the Ribbon should implement `IRibbonWindow`
- `SelectedContentMargin` should be set on the `BackstageTabControl` to hide the ribbon tabs when the Backstage is open
- I added a marker for the home tab so we don't rely on the order of the tabs
- I moved the main group to the shell window and the common groups to the configuration, that way the main group is the first group. Not sure if that's better, but it felt right ;-)

If you have any further questions of any kind or find any bugs/missing features about/in Fluent.Ribbon feel free to create issues on github or contact me on gitter.

@LucasHaines @sibille 
Contacting me via e-mail is prone to be missed by me, as i often overlook mails from senders i don't already know. ;-)